### PR TITLE
Add Makefile, --local test flag, and expanded README docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+INSTALL_DIR ?= /usr/local/bin
+
+.DEFAULT_GOAL := help
+
+.PHONY: help test test-local install manpage
+
+help: ## Show available targets
+	@grep -E '^[a-zA-Z_-]+:.*##' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*##"}; {printf "  %-12s %s\n", $$1, $$2}'
+
+test: ## Run the full test suite (requires remote SSH hosts in test/environs.sh)
+	cd test && bash test_all.sh
+
+test-local: ## Run only local tests (no SSH required)
+	cd test && bash test_all.sh --local
+
+install: ## Install rsync_snapshots to INSTALL_DIR (default: /usr/local/bin)
+	install -m 755 rsync_snapshots $(INSTALL_DIR)/rsync_snapshots
+
+manpage: ## Generate and view the man page (requires help2man)
+	help2man -h "-hv" -v "-Vv" --no-info --name="generate snapshot backups with rsync" ./rsync_snapshots >| /tmp/rsync_snapshots.1
+	man -l /tmp/rsync_snapshots.1

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ rsync_snapshots [-options]
 - `--version`: Print version and exit
 - `--verbose`: Be more verbose
 - `--quiet`: Be quiet (about errors)
-- `--no-execute`: Don't actually copy files, just pretend (i.e. a dry run mode)
+- `-n`, `--dry-run`: Don't actually copy files, just pretend (i.e. a dry run mode)
 - `--cron`: Send output to log file instead of stdout
 - `--conf <conf>`: Read config from <conf>. Defaults to `/usr/local/etc/rsync_snapshots.conf`
 - `--max-delete <n>`: Delete at most n old snapshots
@@ -76,9 +76,59 @@ exclude_from=<file>: Exclude files matching patterns in <file>
 rsync_opts=<opts>: Override default rsync options (default is "-xaSH --numeric-ids --delete")
 ```
 
+## Testing
+
+Run the local tests (no remote hosts required):
+
+```bash
+make test-local
+```
+
+### Running the Full Test Suite
+
+The full test suite includes remote tests that SSH into two hosts. To run them:
+
+1. Edit `test/environs.sh` and set `REM_SRC` and `REM_DST` to your test hosts:
+
+```bash
+REM_SRC="user@source-host"
+REM_DST="user@dest-host"
+```
+
+2. Ensure passwordless SSH access works from your machine to both hosts:
+
+```bash
+ssh-copy-id user@source-host
+ssh-copy-id user@dest-host
+```
+
+3. The tests use `/tmp/rsnap_source` and `/tmp/rsnap_dest` on the remote hosts - make sure those paths are writable.
+
+4. Run the full suite:
+
+```bash
+make test
+```
+
+The three remote test scenarios covered are: remote destination, remote source, and both source and destination remote.
+
 ## Installation
 
-1. Save the script as `rsync_snapshots` somewhere in your PATH
+Install to `/usr/local/bin` (default):
+
+```bash
+make install
+```
+
+To install to a different location:
+
+```bash
+make install INSTALL_DIR=/your/preferred/bin
+```
+
+Or manually:
+
+1. Copy `rsync_snapshots` somewhere in your PATH
 2. Make it executable: `chmod +x rsync_snapshots`
 3. Create a configuration file (see above)
 4. Call the script from a cronjob (see below)

--- a/test/test_all.sh
+++ b/test/test_all.sh
@@ -2,10 +2,20 @@
 
 ./make_dirs.sh
 
+local_only=false
+if [ "${1:-}" = "--local" ]; then
+    local_only=true
+fi
+
 error=""
 
-#for t in local_simple.sh remote_dest.sh remote_src.sh remote_both.sh local_nest.sh local_relative.sh local_expire.sh remote_expire.sh config_error.sh
-for t in local_simple.sh remote_dest.sh remote_src.sh remote_both.sh local_nest.sh local_relative.sh
+if [ "$local_only" = true ]; then
+    tests="local_simple.sh local_nest.sh local_relative.sh"
+else
+    tests="local_simple.sh remote_dest.sh remote_src.sh remote_both.sh local_nest.sh local_relative.sh"
+fi
+
+for t in $tests
 do
     ./$t
     if [ $? -ne 0 ]; then error=true; fi


### PR DESCRIPTION
## Summary

- Adds a `Makefile` with `help`, `test`, `test-local`, `install`, and `manpage` targets, making common workflows discoverable via `make help`
- Adds `--local` flag to `test/test_all.sh` so local tests can run without SSH hosts configured (`make test-local`)
- Expands README with a Testing section (including remote test setup instructions) and updates the Installation section to lead with `make install`
- Corrects `--no-execute` to `-n`/`--dry-run` in the README options list (renamed in b2)

## Test plan

- [ ] `make help` shows all targets
- [ ] `make test-local` runs the three local tests and passes
- [ ] `make test` runs the full suite (requires remote hosts in `test/environs.sh`)
- [ ] `make install INSTALL_DIR=/tmp` installs the script correctly
- [ ] `make manpage` generates and displays the man page (requires `help2man`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)